### PR TITLE
Added information and link for ROS2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,9 @@ If you use this dataset in your research, we would kindly ask that you cite the 
 }
 ```
 
+# ROS2 support
+
+You can find a repository [here](https://github.com/aserbremen/nebula-multirobot-dataset-ros2) containing all the information to prepare and playback the dataset in ROS2.
+
 # Problems or clarification needed?
 Submit ticket [here](https://github.com/NeBula-Autonomy/nebula-multirobot-dataset/issues)


### PR DESCRIPTION
Hello I worked with your multi-robot dataset in ROS2. I compiled a repository containing all the information to prepare, analyze, and play back the NeBula multi-robot dataset in ROS2 (tested in Humble). With the referenced repo it is possible to run and analyze multi-robot slam algorithms in ROS2. 

I spent quite some time on it and thought it might be helpful for researchers in the field already working with ROS2. 

In the repo you can also find the `pose_graph_msgs` interface package of the `LAMP` algorithm ported to ROS2. The interface package is necessary to read in the keyed_scan msgs of the dataset.  

Let me know if this is fine for a pull request or if you have any other suggestions. 